### PR TITLE
feat: add period attribute to user schedule

### DIFF
--- a/app/views/main.py
+++ b/app/views/main.py
@@ -40,7 +40,8 @@ def get_courses(major_id):
 @require_same_user_id
 def save_user_schedule(user_id):
     data = request.json
-    user_schedule = UserSchedule(user_id=user_id)
+    active_period = get_app_config("ACTIVE_PERIOD")
+    user_schedule = UserSchedule(user_id=user_id, period=active_period)
     for item in data['schedule_items']:
         user_schedule.add_schedule_item(**item)
     user_schedule.save()
@@ -106,14 +107,15 @@ def rename_user_schedule(user_id, user_schedule_id):
 @require_jwt_token
 @require_same_user_id
 def edit_user_schedule(user_id, user_schedule_id):
+    active_period = get_app_config("ACTIVE_PERIOD")
     user_schedule = UserSchedule.objects(id=user_schedule_id).first()
     # If the schedule doesn't exist or the user is mismatched,
     # create a new one with the same items.
     if user_schedule is None:
-        user_schedule = UserSchedule(user_id=user_id)
+        user_schedule = UserSchedule(user_id=user_id, period=active_period)
     elif str(user_schedule.user_id.id) != user_id:
         name = f'{user_schedule.name} (copied)'
-        user_schedule = UserSchedule(user_id=user_id, name=name)
+        user_schedule = UserSchedule(user_id=user_id, name=name, period=active_period)
     data = request.json
     user_schedule.clear_schedule_item()
     for editedScheduleItem in data['schedule_items']:

--- a/models/user_schedule.py
+++ b/models/user_schedule.py
@@ -31,6 +31,7 @@ class UserSchedule(mongo.Document):
     schedule_items = mongo.ListField(mongo.EmbeddedDocumentField(ScheduleItem))
     deleted = mongo.BooleanField(default=False)
     created_at = mongo.DateTimeField(default=datetime.now)
+    period = mongo.StringField(max_length=6, default='2021-1')
 
     def add_schedule_item(self, **kwargs):
         data = ScheduleItem(**kwargs)
@@ -51,5 +52,6 @@ class UserSchedule(mongo.Document):
             "id": str(self.id),
             "name": self.name,
             "created_at": self.created_at,
-            "schedule_items": self.__get_schedule_items()
+            "schedule_items": self.__get_schedule_items(),
+            "period": self.period
         }


### PR DESCRIPTION
Add `period` attribute to each user schedules.

<img width="577" alt="Screen Shot 2021-10-24 at 13 57 25" src="https://user-images.githubusercontent.com/47189456/138584095-052c8415-5c9f-491f-8b0c-b2c725062ad3.png">

**The attribute might be useful for:**

- Adding filter created jadwal by term in `Daftar Jadwal`
- Determine the recurrence rule in the `ics` package implemented on https://github.com/ristekoss/susunjadwal-frontend/pull/17

**Note:**

The default value is set to '2021-1' due to our AWS production db only started since last semester. It is stated on the [docs](http://docs.mongoengine.org/apireference.html#mongoengine.base.fields.BaseField) that `default` attribute accepts callable, does that mean we can make the default value of the `period` dynamic?