### PR TITLE
Fix Ulas Kelas' Get All Courses API

### DIFF
--- a/app/views/main.py
+++ b/app/views/main.py
@@ -145,12 +145,11 @@ def scrap_all_schedule():
 @router_main.route('/courses', methods=['GET'])
 def get_all_courses():
     active_period = get_app_config("ACTIVE_PERIOD")
-    period = Period.objects(
-        name=active_period
-    ).first()
+    periods = Period.objects.all()
     all_courses = []
-    for course in period.courses:
-        all_courses.append(course.serialize_ulas_kelas()) 
+    for period in periods:
+        for course in period.courses:
+            all_courses.append(course.serialize_ulas_kelas())
     return (jsonify({
         'courses': all_courses
     }), 200)


### PR DESCRIPTION
Fix `get_all_courses` API only returns courses from one major.