### PR TITLE
[FEAT] change python version to fixed 3.9

### DIFF
--- a/Server-Dockerfile
+++ b/Server-Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:3.9-alpine
 
 WORKDIR /opt/app
 


### PR DESCRIPTION
There is long build if we use python:alpine latest, I found that if we fix the python version to 3.9-alpine the build time reduce by 2x as fast.

# If we use python:alpine
![image](https://user-images.githubusercontent.com/31152419/180608382-ac345656-6e68-40aa-811b-2d9b63483ef4.png)

# If we use python:3.9-alpine
![image](https://user-images.githubusercontent.com/31152419/180608400-781a81e9-ca22-4e9f-b0e7-76f20c40e3a8.png)
