### PR TITLE
[fix] html tag bugs

### DIFF
--- a/scraper/main.py
+++ b/scraper/main.py
@@ -34,7 +34,7 @@ def scrape_courses_with_credentials(period, username, password):
     courses = create_courses(r.text, is_detail=True)
     return courses
 
-
+    
 def scrape_courses(major_kd_org, period, skip_not_detail=False):
     username, password = fetch_credential(major_kd_org)
     if (username is not None) and (password is not None):
@@ -163,14 +163,17 @@ def create_courses(html, is_detail=False):
                 schedules[-1] = schedules[-1].replace('</td>', '')
 
                 rooms = str(sib.contents[11]).split('<br/>')
-                if is_detail:
-                    rooms[0] = rooms[0].replace('<td>', '')
-                else:
-                    rooms[0] = rooms[0].replace('<td class="ce">', '')
+                # Remove possible tags
+                rooms[0] = rooms[0].replace('<td>', '')
+                rooms[0] = rooms[0].replace('<td class="ce">', '')
+                rooms[0] = rooms[0].replace('<td class="ce inf">', '')
                 rooms[-1] = rooms[-1].replace('</td>', '')
 
+                print(str(sib.contents[13]))
                 lecturers = str(sib.contents[13]).split('<br/>')
                 lecturers[0] = lecturers[0].replace('<td>', '')
+                lecturers[0] = lecturers[0].replace('<td class="ce">', '')
+                lecturers[0] = lecturers[0].replace('<td class="ce inf">', '')
                 lecturers[-1] = lecturers[-1].replace('</td>', '')
                 lecturers = [l.lstrip('-') for l in lecturers]
 

--- a/scraper/main.py
+++ b/scraper/main.py
@@ -171,6 +171,10 @@ def create_courses(html, is_detail=False):
 
                 print(str(sib.contents[13]))
                 lecturers = str(sib.contents[13]).split('<br/>')
+
+                # Cover special case in term 2022/1
+                if len(lecturers) > 1 and "sampai" in lecturers[-1]:
+                    lecturers = [' '.join(lecturers)]
                 lecturers[0] = lecturers[0].replace('<td>', '')
                 lecturers[0] = lecturers[0].replace('<td class="ce">', '')
                 lecturers[0] = lecturers[0].replace('<td class="ce inf">', '')


### PR DESCRIPTION
This code resolves some html tags that still not removed with the current scraper, e.g.
![image](https://user-images.githubusercontent.com/70834922/183671992-3174ed0d-9499-4334-8bcb-e45288453c22.png)
After implementation of the code, the behavior becomes
![image](https://user-images.githubusercontent.com/70834922/183672324-dec7e3f2-daa7-4e14-afd3-4ece9097fa43.png)

Note that I include "special case" resolving logic, only for joining "Belum diinformasikan<br\>sampai dengan ...." without bothering other cases (multiple lecturers for example). It could be rolled back if not necessary (I allowed edit for reviewers)
