### PR TITLE
Added Get Courses by KD ORG for UlasKelas Service

### DIFF
--- a/app/views/main.py
+++ b/app/views/main.py
@@ -211,6 +211,24 @@ def get_all_courses_by_major(major_id):
         'courses': all_courses
     }), 200)
 
+"""
+Provides all existing courses, filtered by major KD ORG
+regardless active term/period
+"""
+@router_main.route("/majors/<major_kd_org>/all_courses", methods=["GET"])
+def get_all_courses_by_kd_org(major_kd_org):
+    major = Major.objects(kd_org=major_kd_org).first()
+    if (
+        major is None
+    ):  # there is still no user from desired major that already use update matkul
+        return ({}, 200)
+    periods = Period.objects(major_id=major.id).all()
+    all_courses = []
+    for period in periods:
+        for course in period.courses:
+            all_courses.append(course.serialize_ulas_kelas())
+    return (jsonify({"courses": all_courses}), 200)
+
 '''
 Provides all existing courses
 regardless of major or active term/period

--- a/app/views/main.py
+++ b/app/views/main.py
@@ -215,7 +215,7 @@ def get_all_courses_by_major(major_id):
 Provides all existing courses, filtered by major KD ORG
 regardless active term/period
 """
-@router_main.route("/majors/<major_kd_org>/all_courses", methods=["GET"])
+@router_main.route("/majors/kd/<major_kd_org>/all_courses", methods=["GET"])
 def get_all_courses_by_kd_org(major_kd_org):
     major = Major.objects(kd_org=major_kd_org).first()
     if (


### PR DESCRIPTION
This pull request adds a new endpoint to the API that allows Ulas Kelas service to retrieve all courses filtered by a major's `kd_org` identifier.

**New API endpoint for course retrieval:**

* Added `get_all_courses_by_kd_org` route in `main.py`, which returns all courses for a given major's `kd_org`, independent of active term/period.